### PR TITLE
Rival/topic model to combine two sections

### DIFF
--- a/sections/Pipeline.tex
+++ b/sections/Pipeline.tex
@@ -15,7 +15,7 @@ The extracted articles use the format:
 	\item body
 \end{itemize}
 When training the LDA model, we concatenate the \emph{headline} and \emph{body} for simplicity. \vejleder[inline]{this sentence needs to be moved to another section, it does not match the subsection}
-The preprocessing phase is described in further detail in \autoref{subsec:prepro}.
+The preprocessing phase is described in further detail in \autoref{sec:prepro}.
 This phase applies different \gls{NLP} methods \vejleder[inline]{DETAILS!} to simplify the dataset and remove redundant information.
 After the preprocessing phase, we are left with $\sim$130.000 articles.
 

--- a/sections/Pipeline.tex
+++ b/sections/Pipeline.tex
@@ -21,7 +21,7 @@ After the preprocessing phase, we are left with $\sim$130.000 articles.
 
 \subsection{LDA}
 We apply the \acrfull{lda} to the dataset to generate topic clusters based on the content of the articles. 
-We describe the investigation and selection of hyper parameters in \autoref{subsec:lda}. 
+We describe the investigation and selection of hyper parameters in \autoref{sec:lda}. 
 After the model has been trained, we have a document-topic distribution matrix $\theta$ and a topic-word distribution matrix $\beta$.
 $\theta$ will be used as clusters in the next phase.
 

--- a/sections/introduction/structure.tex
+++ b/sections/introduction/structure.tex
@@ -1,6 +1,6 @@
 The paper is organized as follows:
 In \autoref{sec:related-works}, articles related to topic modeling and random walk are investigated.
-In \autoref{sec:method}, the theory behind LDA and cluster-based PageRank is detailed, and the pipeline is described.
+In \autoref{sec:method}\todo{replace with relevant sections}, the theory behind LDA and cluster-based PageRank is detailed, and the pipeline is described.
 \autoref{sec:experiment}
 \autoref{sec:discussion}
 \autoref{sec:conclusion} and \autoref{sec:future_work}

--- a/sections/method/topic_modelling.tex
+++ b/sections/method/topic_modelling.tex
@@ -1,8 +1,7 @@
-\section{Topic Modeling}\label{sec:topicModelling}
-The objective of topic modeling is to infer topics (collections of words) in a document set.
+\section{\acrlong{lda}}\label{sec:lda}
+\Gls{lda} is topic model method. The objective of topic modeling is to infer topics (collections of words) in a document set.
 The result consists of a topic-word distribution matrix $\beta$, which for each topic gives a distribution of words belonging to said topic, and a document-topic distribution matrix $\theta$ which for each document gives a distribution of topics to which the document belongs to.
 
-\subsubsection{\acrlong{lda}}\label{subsec:lda} \vejleder[inline]{far too late to explain the destails}
 \citeauthor{lda} \cite{lda} introduce \gls{lda}, which has since become a staple within topic modeling.
 \gls{lda} works under the assumption that documents are generated from a specific generative process, and tries to reverse engineer this process.
 This process generates $K$ topics and $D$ documents containing $N_{d}$ words, where $d$ is a document in $D$.

--- a/sections/related_works.tex
+++ b/sections/related_works.tex
@@ -3,7 +3,7 @@ In this section, we investigate existing literature concerning \gls{lda} and sim
 
 \citet{lda} describes a generative statistical model, which is heavily used within topic modeling. 
 The intuition behind the \gls{lda} topic model is that a document has an underlying distribution of topics, and that the words of a document are based on these topics.
-This model is used widely within the field of topic modeling and is somewhat considered a standard, see section \autoref{subsec:lda} for more detail.
+This model is used widely within the field of topic modeling and is somewhat considered a standard, see section \autoref{sec:lda} for more detail.
 
 There also exists a large amount of extensions to \gls{lda}.
 \citet{blei2012topicmodels} describes some of the most significant extensions that are made from relaxing the assumptions of \gls{lda}.


### PR DESCRIPTION
Small change of combining Topic modelling and LDA sections, as topic modeling hardly had anything in it (and what it did have was also mostly LDA related).
Also fixed some references.