### PR TITLE
Remove personalization mentions

### DIFF
--- a/sections/appendix/problems.tex
+++ b/sections/appendix/problems.tex
@@ -41,7 +41,7 @@ To test this initial query handling we generated some queries by taking the 4 hi
 We hoped that each word would only be a significant part of a few topics and that each topic was only a significant part of a few documents.
 If the topic-distribution only contained a few high values, one or more of which would be among the topics belonging to the original document, then we might be able to find the original document, based on the query.
 
-This reverse engineering process formed the base of our query handling, where we converted a query of words into a personalization vector (containing a value between 0 and 1 for each document).
+This reverse engineering process formed the base of our query handling, where we converted a query of words into a personalization vector (containing a value between 0 and 1 for each document), which would be used for Personalized \acrlong{pr}.
 
 However, when we tested this process, we found that the distributions were far too evenly valued to get much meaning out of them.
 To remedy this, we made the distributions contain fewer values by converting all values under a given threshold to 0 and then normalizing the values.


### PR DESCRIPTION
Den eneste mention af personalization er i appendix hvor vi snakker om hvad den originale plan var. Tænker derfor at den godt må komme med, men at vi bare lige tilføjer en hurtig forklaring.
closes #67 